### PR TITLE
Specified API version doesn't contain scope_maps

### DIFF
--- a/samples/containerregistry/manage_scope_map.py
+++ b/samples/containerregistry/manage_scope_map.py
@@ -27,7 +27,6 @@ def main():
     containerregistry_client = ContainerRegistryManagementClient(
         credential=DefaultAzureCredential(),
         subscription_id=SUBSCRIPTION_ID,
-        api_version="2019-12-01-preview"
     )
 
     # Create resource group


### PR DESCRIPTION
ValueError: API version 2019-12-01-preview does not have operation group 'scope_maps'