### PR TITLE
Typo fix in documented example

### DIFF
--- a/samples/costmanagement/README.md
+++ b/samples/costmanagement/README.md
@@ -31,7 +31,7 @@ For example, in Linux-based OS, you can do
 export AZURE_TENANT_ID="xxx"
 export AZURE_CLIENT_ID="xxx"
 export AZURE_CLIENT_SECRET="xxx"
-export SUBSCRIPTION_ID="xxx"
+export AZURE_SUBSCRIPTION_ID="xxx"
 ```
 
 ### Installation


### PR DESCRIPTION
Documented example uses SUBSCRIPTION_ID however the manage_exports.py uses AZURE_SUBSCRIPTION_ID